### PR TITLE
bugfix: properly check tracked files for uncommitted changes

### DIFF
--- a/git-squash
+++ b/git-squash
@@ -15,7 +15,7 @@ if [ "$1" == "" ]; then
   exit 1
 fi
 
-if [ "$(git status -s -u no)" != "" ]; then
+if [ "$(git status -s -uno)" != "" ]; then
   echo "Please commit all changes before squashing"
   exit 1
 fi


### PR DESCRIPTION
Commit d061319 added the good idea of skipping over untracked files when checking for uncommited changes, but introduced a regression where functionally NO files are checked for uncommited changes.

The previous command was equivalent to the following:
`git status -s -u no`
`git status -s --untracked-files=all -- no`

Here "no" is treated as a filename, so only "./no" is checked, and any file changes that would normally be tracked are ignored.

ref: https://git-scm.com/docs/git-status#Documentation/git-status.txt--ultmodegt